### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,29 +18,29 @@
   },
   "homepage": "https://github.com/canopytax/cp-select",
   "devDependencies": {
-    "angular-mocks": ">=1.3.0",
-    "autoprefixer-loader": "^1.2.0",
-    "babel-core": "^4.7.13",
-    "babel-loader": "^4.2.0",
-    "css-loader": "^0.9.1",
-    "html-loader": "^0.2.3",
-    "jasmine-core": "^2.1.3",
-    "karma": "^0.12.31",
-    "karma-chrome-launcher": "^0.1.7",
-    "karma-jasmine": "^0.3.4",
-    "karma-phantomjs-launcher": "^0.1.4",
-    "ngmin": "^0.5.0",
-    "ngmin-webpack-plugin": "^0.1.3",
-    "style-loader": "^0.8.3",
-    "webpack": "^1.4.15"
+    "angular-mocks": "1.4.6",
+    "autoprefixer-loader": "1.2.0",
+    "babel-core": "4.7.16",
+    "babel-loader": "4.3.0",
+    "css-loader": "0.9.1",
+    "html-loader": "0.2.3",
+    "jasmine-core": "2.3.4",
+    "karma": "0.12.37",
+    "karma-chrome-launcher": "0.1.12",
+    "karma-jasmine": "0.3.6",
+    "karma-phantomjs-launcher": "0.1.4",
+    "ngmin": "0.5.0",
+    "ngmin-webpack-plugin": "0.1.3",
+    "style-loader": "0.8.3",
+    "webpack": "1.12.2"
   },
   "dependencies": {
-    "angular": "^1.3.15",
-    "babel": "^4.7.16",
-    "jquery": "^2.1.3",
-    "lodash": "^3.5.0"
+    "angular": "1.4.6",
+    "babel": "4.7.16",
+    "jquery": "2.1.4",
+    "lodash": "3.10.1"
   },
-	"optionalDependencies": {
+  "optionalDependencies": {
     "canopy-styleguide": "latest"
-	}
+  }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
