### PR TITLE
Updated angular-mocks to version 1.2.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/canopytax/cp-select",
   "devDependencies": {
-    "angular-mocks": ">=1.3.0",
+    "angular-mocks": "1.2.29",
     "autoprefixer-loader": "^1.2.0",
     "babel-core": "^4.7.13",
     "babel-loader": "^4.2.0",
@@ -40,7 +40,7 @@
     "jquery": "^2.1.3",
     "lodash": "^3.5.0"
   },
-	"optionalDependencies": {
+  "optionalDependencies": {
     "canopy-styleguide": "latest"
-	}
+  }
 }


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
